### PR TITLE
Adding lint and test CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,26 @@
+name: lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'v2/**' # Only run on changes to the v2 directory
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        with:
+          version: latest
+          working-directory: v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'v2/**' # Only run on changes to the v2 directory
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: stable
+      - run: make test-cov
+        working-directory: v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,0 +1,15 @@
+test:
+	@echo "  >  Validating code ..."
+	@go vet ./...
+	@go clean -testcache
+	@go test ./...
+
+tidy:
+	@echo "  >  Tidying go.mod ..."
+	@go mod tidy
+
+test-cov:
+	@echo "Running tests and generating coverage output ..."
+	@go test ./... -coverprofile coverage.out -covermode count
+	@sleep 2 # Sleeping to allow for coverage.out file to get generated
+	@echo "Current test coverage : $(shell go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+') %"


### PR DESCRIPTION
This PR adds 2 GHA workflows: lint and test that will provide feedback on all golang changes within the `v2` directory