### PR TITLE
feat: add upgrade script for projects using v1 insights

### DIFF
--- a/upgrading/.gitignore
+++ b/upgrading/.gitignore
@@ -1,0 +1,4 @@
+security-insights.yml
+insights-v1.yml
+schema.cue
+v1-schema.cue

--- a/upgrading/UPGRADING.md
+++ b/upgrading/UPGRADING.md
@@ -1,0 +1,61 @@
+# Upgrading from insights v1 to v2
+
+If a project has an existing version 1 file, ex: https://raw.githubusercontent.com/in-toto/go-witness/refs/heads/main/SECURITY-INSIGHTS.yml that file can be used as the basis to create a version 2 file.
+
+## Automated conversion process
+
+### Dependencies
+
+The script depends on `curl` and `cue`
+
+### Generate the new `security-insights.yml`
+
+Using the example insights file from `go-witness`
+
+```sh
+./upgrade-to-v2.sh \
+    "https://raw.githubusercontent.com/in-toto/go-witness/refs/heads/main/SECURITY-INSIGHTS.yml" \
+    "go-witness"
+```
+
+You'll see output like:
+
+```
+Downloading v1 schema
+Downloading v1 insights
+Validating v1 insights against the v1 schema
+"security-testing".0."tool-version": conflicting values 2 and string (mismatched types int and string):
+    ./insights-v1.yml:49:17
+    ./v1-schema.cue:15:2
+    ./v1-schema.cue:150:25
+    ./v1-schema.cue:174:21
+Error: v1 insights file failed schema validation. Please correct the errors in v1 data before attempting another conversion
+```
+
+Edit `insights-v1.yml` to correctly specify a value of `"2"` for all `security-testing.*.tool-version` values and then re-run the script.
+
+```sh
+./upgrade-to-v2.sh \
+    "https://raw.githubusercontent.com/in-toto/go-witness/refs/heads/main/SECURITY-INSIGHTS.yml" \
+    "go-witness"
+```
+
+You'll see output like:
+
+```
+Found local v1-schema.cue, skipping download
+Found local insights-v1.yml, skipping download
+Validating v1 insights against the v1 schema
+Found local schema.cue, skipping v2 schema download
+Converting v1 data to v2 insights and saving to security-insights.yml
+Validating v2 insights against the v2 schema
+
+
+Thank you for using the v2 upgrade script.
+
+The v1 insights data in https://raw.githubusercontent.com/in-toto/go-witness/refs/heads/main/SECURITY-INSIGHTS.yml has been converted to the v2 schema and saved to security-insights.yml. You must review the file and make any necessary adjustments to resolve TODOs before using it.
+```
+
+### Validate conversion and address TODOs
+
+The conversion process will use default values as needed if it cannot determine the v1 source or there is no mapping from a v1 field to v2 field. You MUST review tne v2 output and replace all occurences of `TODO` with the relevant data for your project.

--- a/upgrading/upgrade-to-v2.sh
+++ b/upgrading/upgrade-to-v2.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+VI_INSIGHTS=$1
+PROJECT_NAME=$2
+
+V1_SCHEMA_URL=$3
+# Check if the user provided a v1 schema URL
+if [ -z "$V1_SCHEMA_URL" ]; then
+    V1_SCHEMA_URL='https://raw.githubusercontent.com/ossf/security-insights-spec/main/schema/v1-schema.cue'
+    # V1_SCHEMA_URL='https://raw.githubusercontent.com/trumant/security-insights-spec/refs/heads/convert-v1-to-v2/v1-schema.cue'
+fi
+
+'https://raw.githubusercontent.com/ossf/security-insights-spec/main/schema/v1-schema.cue'
+# check if the user provided a v2 schema URL
+V2_SCHEMA_URL=$4
+if [ -z "$V2_SCHEMA_URL" ]; then
+    V2_SCHEMA_URL='https://github.com/ossf/security-insights-spec/releases/download/v2.0.0/schema.cue'
+    # V2_SCHEMA_URL='https://raw.githubusercontent.com/trumant/security-insights-spec/refs/heads/convert-v1-to-v2/schema.cue'
+fi
+
+if [ -f "v1-schema.cue" ]; then
+    echo "Found local v1-schema.cue, skipping download"
+else
+    echo "Downloading v1 schema"
+    curl "$V1_SCHEMA_URL" -o v1-schema.cue --silent
+fi
+
+# Check if insights-v1.yml exists locally first
+if [ -f "insights-v1.yml" ]; then
+    echo "Found local insights-v1.yml, skipping download"
+else
+    echo "Downloading v1 insights"
+    curl "$VI_INSIGHTS" -o insights-v1.yml --silent
+fi
+
+# double-check that it actually conforms to the v1 schema
+echo "Validating v1 insights against the v1 schema"
+
+# convert the v1 data to v2 data
+if ! cue vet insights-v1.yml v1-schema.cue -d '#v1'; then
+    echo "Error: v1 insights file failed schema validation. Please correct the errors in v1 data before attempting another conversion"
+    exit 1
+fi
+
+if [ -f "schema.cue" ]; then
+    echo "Found local schema.cue, skipping v2 schema download"
+else
+    echo "Downloading v2 schema"
+    curl -L "$V2_SCHEMA_URL" -o schema.cue --silent
+fi
+
+echo "Converting v1 data to v2 insights and saving to security-insights.yml"
+cue export .:security_insights_spec -l input: insights-v1.yml -e output --out yaml -t project="$PROJECT_NAME" > security-insights.yml
+
+echo "Validating v2 insights against the v2 schema"
+cue vet security-insights.yml schema.cue -d '#v2'
+
+echo ""
+echo ""
+echo "Thank you for using the v2 upgrade script."
+echo ""
+echo "The v1 insights data in $VI_INSIGHTS has been converted to the v2 schema and saved to security-insights.yml. You must review the file and make any necessary adjustments to resolve TODOs before using it."

--- a/upgrading/v1-to-v2.cue
+++ b/upgrading/v1-to-v2.cue
@@ -1,0 +1,97 @@
+package security_insights_spec
+
+// place the yaml input here with "-l"
+input: _
+
+// also take a project name as a tag input "-t project=foo"
+project_name: string @tag(project)
+
+// validate the input against the v1 schema
+input: #v1
+
+// helpful defaults
+default_administrators: [
+    {
+        name: "TODO: replace with actual administrators"
+        affiliation: "Foo"
+        email: "joe.bob@email.com"
+        social: "https://bsky.com/joebob"
+        primary: true
+    }
+]
+default_repositories: [
+    {
+        name: "Foo"
+        url: "https://my.vcs/foobar/foo"
+        comment: "TODO: replace with actual repository(ies)"
+    }
+]
+default_repository: {
+    url: "https://TODO/your/project"
+    status: "active"
+    "accepts-change-request": *(input."contribution-policy"."accepts-pull-requests") | true
+    "accepts-automated-change-request": *(input."contribution-policy"."accepts-automated-pull-requests") | true
+    "core-team": [
+        {
+            name: "TODO: replace with actual core team members"
+            affiliation: "Foo Bar"
+            email: "alicewhite@email.com"
+            social: "https://bsky.com/alicewhite"
+            primary: true
+        }
+    ]
+    license: {
+        url: *(input.header.license) | "https://foo.bar/LICENSE"
+        expression: "TODO: replace with actual license SPDX expression"
+    }
+    security: {
+        assessments: {
+            self: {
+                comment: "Self assessment has not yet been completed."
+            }
+        }
+    }
+}
+
+security_contact: {
+    for k,v in input."security-contacts" {
+        if v.primary && v.type == "email" {
+            name: v.value
+            primary: v.primary
+            email: v.value
+        }
+    }
+}
+
+// convert the input to the v2 schema
+output: header: {
+    "schema-version": "2.0.0"
+    "last-updated": input.header."last-updated"
+    "last-reviewed": input.header."last-reviewed"
+    url: input.header."project-url"
+}
+output: {
+    project: {
+        name: project_name
+        homepage: input.header."project-url"
+        roadmap: input."project-lifecycle".roadmap
+        "vulnerability-reporting": {
+            "reports-accepted": input."vulnerability-reporting"."accepts-vulnerability-reports"
+            "bug-bounty-available": *(input."vulnerability-reporting"."bug-bounty-available") | false
+            if input."vulnerability-reporting"."security-policy" != "" {
+                "security-policy": input."vulnerability-reporting"."security-policy"
+            }
+            contact: security_contact
+        },
+        administrators: default_administrators,
+        repositories: default_repositories,
+        documentation: {
+            if input."contribution-policy"."code-of-conduct" != "" {
+                "code-of-conduct": input."contribution-policy"."code-of-conduct"
+            }
+        },
+    },
+    repository: default_repository
+}
+
+output: #v2


### PR DESCRIPTION
This PR adds docs and a script that can help maintainers on projects that have adopted the v1 version of `security-insights.yml` to quickly generate a new v2 schema-compatible `security-insights.yml` that reuses data from the prior version.

## How was this tested?

I ran:

```shell
$ cd upgrading
$ ./upgrade-to-v2.sh \
    "https://raw.githubusercontent.com/in-toto/go-witness/refs/heads/main/SECURITY-INSIGHTS.yml" \
    "go-witness" \
    "https://raw.githubusercontent.com/trumant/security-insights-spec/refs/heads/convert-v1-to-v2/v1-schema.cue" \
    "https://raw.githubusercontent.com/trumant/security-insights-spec/refs/heads/convert-v1-to-v2/schema.cue"
```

This produced:

```yaml
header:
  schema-version: 2.0.0
  last-updated: "2023-12-20"
  last-reviewed: "2023-12-20"
  url: https://github.com/in-toto/go-witness
project:
  name: go-witness
  homepage: https://github.com/in-toto/go-witness
  roadmap: https://github.com/orgs/in-toto/projects/4/views/3
  vulnerability-reporting:
    reports-accepted: true
    bug-bounty-available: false
    security-policy: https://github.com/in-toto/go-witness/SECURITY.md
    contact:
      name: security@testifysec.com
      primary: true
      email: security@testifysec.com
  administrators:
    - name: 'TODO: replace with actual administrators'
      affiliation: Foo
      email: joe.bob@email.com
      social: https://bsky.com/joebob
      primary: true
  repositories:
    - name: Foo
      url: https://my.vcs/foobar/foo
      comment: 'TODO: replace with actual repository(ies)'
  documentation:
    code-of-conduct: https://github.com/in-toto/go-witness/blob/main/CODE_OF_CONDUCT.md
repository:
  url: https://TODO/your/project
  status: active
  accepts-change-request: true
  accepts-automated-change-request: true
  core-team:
    - name: 'TODO: replace with actual core team members'
      affiliation: Foo Bar
      email: alicewhite@email.com
      social: https://bsky.com/alicewhite
      primary: true
  license:
    url: https://github.com/in-toto/go-witness/blob/main/LICENSE
    expression: 'TODO: replace with actual license SPDX expression'
  security:
    assessments:
      self:
        comment: Self assessment has not yet been completed.
```