### PR TITLE
chore: replace unmaintained module dependency

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -2,4 +2,4 @@ module github.com/ossf/si-tooling/v2
 
 go 1.23
 
-require gopkg.in/yaml.v3 v3.0.1
+require github.com/goccy/go-yaml v1.17.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,4 +1,2 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=

--- a/v2/si/import.go
+++ b/v2/si/import.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 type FileAPIResponse struct {


### PR DESCRIPTION
gopkg.in/yaml.v3 is now archived and no longer
maintained, so we should adopt a maintained
replacement module

This PR replaces it with github.com/goccy/go-yaml