### PR TITLE
fix: retract erroneous go release

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -16,3 +16,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+    v3.0.0 // Published accidentally
+    v3.0.1 // Contains retraction only
+)


### PR DESCRIPTION
Sometime, somehow, it seems I released and attempted to delete a v3 release — but it got fetched by go before deletion and now it occupies the space of @latest.

This is the process to correct that, per https://go.dev/ref/mod#go-mod-file-retract