### PR TITLE
ci: update GitHub Actions and add repo maintenance configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @eddie-knight

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,42 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["python", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["go", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/checkout@v6.0.2
         with:
-          go-version: stable
+          persist-credentials: false
+      - uses: actions/setup-go@v6.2.0
+        with:
+          go-version-file: v2/go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8.0.0
+        uses: golangci/golangci-lint-action@vfce8c989772fe5b89e9c70c94aac89041cfb3aa9
         with:
           version: v2.1
           working-directory: v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version-file: v2/go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@vfce8c989772fe5b89e9c70c94aac89041cfb3aa9
+        uses: golangci/golangci-lint-action@fce8c989772fe5b89e9c70c94aac89041cfb3aa9
         with:
           version: v2.1
           working-directory: v2


### PR DESCRIPTION
## What

Add CODEOWNERS and Dependabot configuration, and update CI workflow to use latest action versions with improved security settings.

## Why

Brings CI actions up to date (checkout v6, setup-go v6, pins golangci-lint to a commit SHA), hardens the workflow with persist-credentials: false, and uses go-version-file for consistent Go version management. CODEOWNERS and Dependabot ensure proper review ownership and automated dependency updates.

## Notes

- golangci-lint-action is pinned to a full commit SHA rather than a semver tag — not sure if it is an immutable action
- Go version now derived from v2/go.mod instead of "stable", so the CI Go version is tied to what the module declares
- Dependabot groups minor/patch updates together, so major bumps will still get individual PRs