### PR TITLE
chore: update security-insights.yml to spec v2.2.0 and add workflow to vet file

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,7 +1,7 @@
 header:
-  schema-version: 2.0.0
-  last-updated: '2025-04-10'
-  last-reviewed: '2025-04-10'
+  schema-version: 2.2.0
+  last-updated: "2026-02-16"
+  last-reviewed: "2026-02-16"
   url: https://github.com/ossf/si-tooling
   project-si-source: https://raw.githubusercontent.com/ossf/security-insights-spec/refs/heads/main/.github/security-insights.yml
 
@@ -11,9 +11,9 @@ repository:
   accepts-change-request: true
   accepts-automated-change-request: false
   core-team:
-    - name:        Eddie Knight
+    - name: Eddie Knight
       affiliation: Sonatype
-      primary:     true
+      primary: true
   license:
     url: https://github.com/ossf/si-tooling?tab=Apache-2.0-1-ov-file#readme
     expression: Apache-2.0
@@ -24,5 +24,5 @@ repository:
   release:
     automated-pipeline: false
     distribution-points:
-      - uri:  https://github.com/ossf/si-tooling/releases
+      - uri: https://github.com/ossf/si-tooling/releases
         comment: GitHub Release Page

--- a/.github/workflows/si-validation.yml
+++ b/.github/workflows/si-validation.yml
@@ -16,16 +16,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-      - uses: cue-lang/setup-cue@v1.0.1
-      - name: Extract schema version
-        id: version
-        run: |
-          VERSION=$(yq '.header.schema-version' .github/security-insights.yml)
-          echo "schema-version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Download schema
-        run: |
-          curl -fsSL \
-            "https://raw.githubusercontent.com/ossf/security-insights/v${{ steps.version.outputs.schema-version }}/spec/schema.cue" \
-            -o schema.cue
-      - name: Validate
-        run: cue vet schema.cue .github/security-insights.yml
+      - name: Validate Security Insights
+        uses: revanite-io/security-insights-action@v1.0.0
+        with:
+          file: .github/security-insights.yml

--- a/.github/workflows/si-validation.yml
+++ b/.github/workflows/si-validation.yml
@@ -1,0 +1,31 @@
+---
+name: Validate Security Insights
+
+on:
+  pull_request:
+    paths:
+      - ".github/security-insights.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: cue-lang/setup-cue@v1.0.1
+      - name: Extract schema version
+        id: version
+        run: |
+          VERSION=$(yq '.header.schema-version' .github/security-insights.yml)
+          echo "schema-version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Download schema
+        run: |
+          curl -fsSL \
+            "https://raw.githubusercontent.com/ossf/security-insights/v${{ steps.version.outputs.schema-version }}/spec/schema.cue" \
+            -o schema.cue
+      - name: Validate
+        run: cue vet schema.cue .github/security-insights.yml


### PR DESCRIPTION
## What

Update the security-insights.yml schema version from 2.0.0 to 2.2.0 and refresh the last-updated and last-reviewed dates. Use security-insights-action GitHub Actionto validate the security-insights.yml file against the official OSSF Security Insights CUE schema on PRs.

## Why

Aligns the repository's security insights file with the latest spec version (v2.2.0) that this tooling already supports. Automated validation catches schema drift and ensures the
security-insights.yml file remains compliant with the declared spec version before changes are merged.

## Notes

- YAML formatting was normalized (removed extra whitespace alignment in core-team and distribution-points fields) — no semantic changes beyond the version and date updates