### PR TITLE
ci: pin actions to SHAs and apply security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,23 +4,27 @@ name: CI Checks
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: v2/go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@e52a9f899623adbdb986c05b9a8f7a8cf4138fc3
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.1
+          version: v2.12.2
           working-directory: v2
       - name: run tests
         run: make covcheck

--- a/.github/workflows/si-validation.yml
+++ b/.github/workflows/si-validation.yml
@@ -6,17 +6,21 @@ on:
     paths:
       - ".github/security-insights.yml"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Validate Security Insights
-        uses: revanite-io/security-insights-action@v1.0.0
+        uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2 # v1.0.0
         with:
           file: .github/security-insights.yml


### PR DESCRIPTION
## What

Pin all GitHub Actions in `ci.yml` and `si-validation.yml` to commit SHAs at the latest release, add `step-security/harden-runner` as the first step in each job, switch to deny-all default permissions with per-job grants, and bump golangci-lint binary from `v2.1` to `v2.12.2`.

## Why

Tag references can be force-moved by upstream owners, so pinning to full commit SHAs is the only way to make third-party action versions reproducible and audit-friendly. Harden-runner detects unexpected egress during workflow runs, and tightening permissions to the minimum each job actually needs reduces blast radius if any action is ever compromised.

## Notes

- Major version bumps included: `actions/setup-go` v5→v6 (already at v6 upstream), `golangci/golangci-lint-action` effectively v8→v9.2.1, and the `golangci-lint` binary v2.1→v2.12.2.
- `harden-runner` is set to `egress-policy: audit`, not `block` — first pass is observation-only so we can see the baseline before considering a lockdown.
- `.yml` extension and `concurrency` block intentionally left untouched in this PR.

## Testing

- `make covcheck` locally: tests pass, coverage 76.2% (threshold 75%).
- `golangci-lint run ./...` against `v2/` with the new v2.12.2 binary: 0 issues.
- CI workflows should run on this PR to confirm the action upgrades work end-to-end.